### PR TITLE
商品登録機能

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -67,7 +67,8 @@ class ProductsController < ApplicationController
   private
 
   def products_params
-    params.require(:product).permit(:name,:description,:price,:shipping_charge,:shipping_method,:shipping_origin,:shipping_day,:product_condition,product_images_attributes:[:image_url])
+    @category=Category.find_by(name:params[:category_id])
+    params.require(:product).permit(:name,:description,:price,:shipping_charge,:shipping_method,:shipping_origin,:shipping_day,:product_condition,product_images_attributes:[:image_url]).merge(category_id:@category.id)
   end
 
 end

--- a/db/migrate/20200103111335_add_category_to_products.rb
+++ b/db/migrate/20200103111335_add_category_to_products.rb
@@ -1,0 +1,5 @@
+class AddCategoryToProducts < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :products, :category, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_30_075502) do
+ActiveRecord::Schema.define(version: 2020_01_03_111335) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "postal_code", null: false
@@ -68,6 +68,8 @@ ActiveRecord::Schema.define(version: 2019_12_30_075502) do
     t.string "shipping_charge"
     t.string "shipping_day"
     t.string "product_condition"
+    t.bigint "category_id"
+    t.index ["category_id"], name: "index_products_on_category_id"
   end
 
   create_table "produt_statuses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -144,6 +146,7 @@ ActiveRecord::Schema.define(version: 2019_12_30_075502) do
   end
 
   add_foreign_key "product_images", "products"
+  add_foreign_key "products", "categories"
   add_foreign_key "users_exhibits", "products"
   add_foreign_key "users_exhibits", "users"
   add_foreign_key "users_purchases", "products"


### PR DESCRIPTION
#what
商品出品機能・サイズ以外（サイズの登録は必須が終わってからします。）
#why
商品が出品できるようにするため

・カテゴリーカラムの外部キーを追加してサイズ以外の商品登録できるようにしました
・LGTM後、テストを記述します。

https://gyazo.com/5452b79b91c7ba03fb297f7902554cac